### PR TITLE
Secure nginx user and remove relay1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,8 +104,8 @@ dev: build-relay start-redis ## runs relay on watch mode and shows logs
 
 ci: ## runs tests in github actions
 	printf "RELAY_URL=\nCERTBOT_EMAIL=\nCLOUDFLARE=false\n" > config
-	CRYPTOGRAPHY_DONT_BUILD_RUST=1 NODE_ENV=development $(MAKE) deploy
-	sleep 15
+	APP_PORT=5555 NODE_ENV=development $(MAKE) deploy
+	sleep 20
 	docker service logs --tail 100 $(project)_nginx
 	docker service logs --tail 100 $(project)_relay0
 	TEST_RELAY_URL=wss://localhost $(MAKE) test-client

--- a/ops/docker-compose.prod.yml
+++ b/ops/docker-compose.prod.yml
@@ -7,8 +7,8 @@ services:
       APP_ENV: ${NODE_ENV:-production}
       EMAIL: ${CERTBOT_EMAIL}
       CONTAINER_NAME: relay
-      APP_PORT: 5000
-      APP_QTY: 2
+      APP_PORT: ${APP_PORT:-5000}
+      APP_QTY: ${APP_QTY:-1}
       CLOUDFLARE: ${CLOUDFLARE}
     depends_on:
       - relay
@@ -17,19 +17,7 @@ services:
     image: ${RELAY_IMAGE}
     environment:
       NODE_ENV: ${NODE_ENV:-production}
-      REDIS_URL: redis://redis:6379/0
     deploy:
       resources:
-        limits:
-          memory: 3G
         reservations:
-          cpus: '0.4'
-  relay1:
-    image: ${RELAY_IMAGE}
-    environment:
-      NODE_ENV: production
-      REDIS_URL: redis://redis:6379/0
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+          cpus: '0.6'

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -14,10 +14,10 @@ services:
       mode: global
     # This port format is needed to get real ip address of the client
     ports:
-      - target: 80
+      - target: 8080
         published: 80
         mode: host
-      - target: 443
+      - target: 8443
         published: 443
         mode: host
     volumes:

--- a/ops/nginx/entry.sh
+++ b/ops/nginx/entry.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Set default variables
 root_domain="${DOMAIN_URL:-localhost}"
+app_env="${APP:-development}"
 manage_root_domain=${MANAGE_ROOT_DOMAIN:-true}
 email="${EMAIL:-noreply@gmail.com}"
 docker_containers="${SUBDOMAINS}"
@@ -76,8 +77,8 @@ function configSubDomain () {
   makeCert "$fullDomain" $certDirectory
   cat - > "$SERVERS/$fullDomain.conf" <<EOF
 server {
-  listen  80;
-  listen [::]:80;
+  listen  8080;
+  listen [::]:8080;
   server_name $fullDomain;
   include /etc/nginx/letsencrypt.conf;
   location / {
@@ -85,13 +86,13 @@ server {
   }
 }
 server {
-  listen  443 ssl;
-  listen [::]:443 ssl;
+  listen  8443 ssl;
+  listen [::]:8443 ssl;
   ssl_certificate       $certDirectory/fullchain.pem;
   ssl_certificate_key   $certDirectory/privkey.pem;
   server_name $fullDomain;
   location / {
-		proxy_pass "http://$subDomain:$dockerPort";
+    proxy_pass "http://$subDomain:$dockerPort";
   }
 }
 EOF
@@ -117,7 +118,7 @@ upstream upstream_app {
 EOF
   for i in $(seq 0 $((appQty - 1))); do
     if [[ $i == 0 ]]; then
-      echo "server $dockerContainerName$i:$port max_fails=1 fail_timeout=1s;" >> $configPath
+      echo "server $dockerContainerName$i:$port max_fails=1 fail_timeout=10s;" >> $configPath
     else
       echo "server $dockerContainerName$i:$port backup;" >> $configPath
     fi
@@ -131,11 +132,22 @@ function configRootDomain () {
   certDirectory=$LETSENCRYPT/$domain
   mkdir -vp $certDirectory
   makeCert $domain $certDirectory
+
+  ddosMitigation=$(printf '
+    limit_req_zone $remote_addr zone=req_zone_one:100m rate=1000r/m;
+    limit_req zone=req_zone_one;
+    limit_except GET POST { deny all; }
+    ')
+  # Only add the DDoS protection in production mode
+  if [[ $app_env == "development" ]]; then
+    ddosMitigation=""
+  fi 
   configPath="$SERVERS/$domain.conf"
+
   cat - > $configPath <<EOF
 server {
-  listen 80;
-  listen [::]:80;
+  listen 8080;
+  listen [::]:8080;
   server_name $domain;
   include /etc/nginx/letsencrypt.conf;
   location / {
@@ -143,8 +155,8 @@ server {
   }
 }
 server {
-  listen 443 ssl;
-  listen [::]:443 ssl;
+  listen 8443 ssl;
+  listen [::]:8443 ssl;
   server_name $domain;
   # https://stackoverflow.com/questions/35744650/docker-network-nginx-resolver
   resolver 127.0.0.11 valid=5s ipv6=off;
@@ -153,13 +165,13 @@ server {
   ssl_certificate_key       $certDirectory/privkey.pem;
 
   location / {
+    $ddosMitigation
     proxy_read_timeout      1800;
     proxy_send_timeout      1800;
     keepalive_timeout       1800;
     proxy_set_header        Host \$host;
     proxy_set_header        http_x_forwarded_for  \$remote_addr;
-    set \$app_server        http://upstream_app;
-    proxy_pass              \$app_server;
+    proxy_pass              http://upstream_app;
 
     # Websocket must have configs
     proxy_http_version      1.1;

--- a/ops/nginx/nginx.Dockerfile
+++ b/ops/nginx/nginx.Dockerfile
@@ -1,14 +1,26 @@
-FROM nginx:1.17-alpine
+FROM nginx:1.19-alpine
 
 RUN apk add --update --no-cache openssl-dev libffi-dev  musl-dev python3-dev py3-pip gcc openssl bash && \
   ln -fs /dev/stdout /var/log/nginx/access.log && \
   ln -fs /dev/stdout /var/log/nginx/error.log
 
-RUN pip3 install certbot-dns-cloudflare
+RUN CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install certbot-dns-cloudflare
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./letsencrypt.conf /etc/nginx/letsencrypt.conf
-COPY ./dhparams.pem /etc/ssl/dhparams.pem
-COPY ./entry.sh /root/entry.sh
+COPY ./dhparams.pem /etc/nginx/dhparams.pem
+COPY ./entry.sh /entry.sh
 
-ENTRYPOINT ["/bin/bash", "/root/entry.sh"]
+ENV nginxDirs="/etc/letsencrypt \
+  /etc/nginx \
+  /etc/nginx/servers \
+  /run/secrets \
+  /var/www \
+  /var/cache/nginx \
+  /var/log \
+  /var/lib/letsencrypt"
+
+RUN mkdir -p $nginxDirs
+RUN chown -R nginx:nginx /entry.sh $nginxDirs
+USER nginx
+ENTRYPOINT /entry.sh

--- a/ops/nginx/nginx.conf
+++ b/ops/nginx/nginx.conf
@@ -1,44 +1,70 @@
-user nginx;
+# nginx: [warn] the "user" directive makes sense only if the master process runs with super-user privileges, ignored in /etc/nginx/nginx.conf:1
+# user nginx;
 daemon off;
-pid /run/nginx.pid;
+pid /etc/nginx/nginx.pid;
 worker_processes 1;
+worker_rlimit_nofile 200000;
+timer_resolution 100ms;
 
 events {
-    worker_connections 200000;
+  worker_connections 200000;
+  multi_accept on;
+  use epoll;
 }
 
 http {
-  sendfile on;
-  tcp_nopush on;
   tcp_nodelay on;
-  keepalive_timeout 100;
   types_hash_max_size 2048;
-
   gzip on;
   gzip_types text/plain application/javascript application/json;
   gzip_disable "msie6";
-
   include         /etc/nginx/mime.types;
   default_type  application/octet-stream;
-  error_log /var/log/nginx/error.log;
+
+  # logs
+  error_log  /var/log/nginx/error.log warn;
   log_format full_logs '$remote_addr [$time_local] '
             'STATUS_CODE: $status '
-            '<$http_user_agent> '
+            'USER_AGENT: $http_user_agent '
+            'FORWARDED_FOR: $http_x_forwarded_for '
             'UPSTREAM: $upstream_addr$request_uri '
             'REQUEST: $request '
             'BODY: $request_body';
+  access_log /var/log/nginx/access.log full_logs buffer=16k;
 
-  access_log /var/log/nginx/access.log full_logs;
-
-  ssl_dhparam               /etc/ssl/dhparams.pem;
-  ssl_session_cache         shared:SSL:4m;  # This is size not duration
-  ssl_session_timeout       1m;
+  # ssl
+  ssl_dhparam               /etc/nginx/dhparams.pem;
+  ssl_session_cache         shared:SSL:50m; # This is size not duration
+  ssl_session_timeout       10m;
   ssl_protocols             TLSv1.2 TLSv1.3; 
   ssl_prefer_server_ciphers on;
   ssl_ecdh_curve            secp384r1;
   ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384';
   root /var/www/letsencrypt;
 
+  server_tokens             off;
+  server_name_in_redirect   off;
+
+  # Server timeouts
+  keepalive_timeout         20; # has to greater than the relay timeout
+  #reset_timedout_connection on; # reset timed out connections freeing ram
+  send_timeout              20s; # time between packets nginx is allowed to pause when sending the client data
+  keepalive_requests        1000; # number of requests per connection, does not affect HTTP2
+  client_body_timeout       10s;
+  client_header_timeout     10s;
+
+  # Buffers
+  client_body_buffer_size         8k;
+  client_max_body_size            1m;
+  client_body_temp_path           client_body_temp;
+  client_header_buffer_size       1m;
+  large_client_header_buffers     8 8k;
+  proxy_buffer_size               128k;
+  proxy_buffers                   16 128k;
+  proxy_busy_buffers_size         128k;
+
+
+  # entry script servers
   include /etc/nginx/servers/*;
 }
 

--- a/servers/relay/src/http.ts
+++ b/servers/relay/src/http.ts
@@ -88,7 +88,7 @@ export class HttpService {
         assertType(req.body, "topic");
         assertType(req.body, "webhook");
 
-        await this.redis.setNotification({
+        this.redis.setNotification({
           topic: req.body.topic,
           webhook: req.body.webhook,
         });


### PR DESCRIPTION
Changes:

- Remove root user from nginx container to avoid privilege escalation from within the nginx container.
- Remove the fallback relay1 since relay0 doesn't crash with OOM anymore
- Increase nginx upstream timeout from 1 second to 10 seconds
   - This failover timeout was in place to make the transition smoother from relay0 to relay1 when relay0 died with OOM. Increasing this failover timeout makes nginx to have more patience and not return a 503 error to the clients.
 -  Add DDoS protection in production mode to 1000 request / min
 - Add some buffer size limits for nginx but I don't think they will exceed the WebSocket buffer sizes so it shoudn't be a problem. 
 - Add some more client timeouts.
 
 This is currently running on staging.
 
~~I'm going to squash all of these commits since a lot of them don't add much benefit and are actually bad information.~~